### PR TITLE
Turning off compression when Perlbal X-Reproxy-Url header set

### DIFF
--- a/lib/Plack/Middleware/Deflater.pm
+++ b/lib/Plack/Middleware/Deflater.pm
@@ -32,6 +32,10 @@ sub call {
         return if $env->{HTTP_CONTENT_RANGE};
 
         my $h = Plack::Util::headers($res->[1]);
+
+        # do not compress Perlbal reproxy URLs
+        return if $h->get('X-REPROXY-URL');
+
         my $content_type = $h->get('Content-Type') || '';
         $content_type =~ s/(;.*)$//;
         if ( my $match_cts = $self->content_type ) {

--- a/t/headers.t
+++ b/t/headers.t
@@ -1,0 +1,36 @@
+use strict;
+use Test::More;
+#use Test::Requires qw(IO::Handle::Util);
+#use IO::Handle::Util qw(:io_from);
+use HTTP::Request::Common;
+use Plack::Builder;
+use Plack::Test;
+use Plack::Middleware::Deflater;
+$Plack::Test::Impl = "Server";
+
+# no compression on X-REPROXY-URL
+my $app = builder {
+    enable 'Deflater', content_type => 'text/html', vary_user_agent => 1;
+    sub {
+        [   200,
+            [   'Content-Length' => '100',
+                'Content-type'   => 'text/plain',
+                'X-REPROXY-URL' =>
+                    'http://10.0.0.1:7500/dev1/0/000/000/0000000001.fid',
+            ],
+            ['http://10.0.0.1:7500/dev1/0/000/000/0000000001.fid'],
+        ];
+        }
+};
+
+test_psgi
+    app    => $app,
+    client => sub {
+    my $cb  = shift;
+    my $req = HTTP::Request->new( GET => "http://localhost/" );
+    my $res = $cb->($req);
+    isnt $res->content_encoding, 'gzip', 'no content-encoding';
+    };
+
+done_testing;
+


### PR DESCRIPTION
Hi Miyagawa,
Small patch for P::MW::Deflater - would something like this be useful or is it too specific?
it's required when using MogileFS and Perlbal for example. Without it, the Content-Encoding header is not unset by Perlbal, and browser fails (has Content-Encoding set, but non-zipped body).
thanks,
Michael
