### PR TITLE
Do no clobber existing Content-Encoding

### DIFF
--- a/lib/Plack/Middleware/Deflater.pm
+++ b/lib/Plack/Middleware/Deflater.pm
@@ -54,6 +54,9 @@ sub call {
             push @vary, 'User-Agent' if $self->vary_user_agent;
             $h->set('Vary' => join(",", @vary));
 
+            # Do not clobber already existing encoding
+            return if $h->exists('Content-Encoding') && $h->get('Content-Encoding') ne 'identity';
+
             # some browsers might have problems, so set no-compress
             return if $env->{"psgix.no-compress"};
 

--- a/lib/Plack/Middleware/Deflater.pm
+++ b/lib/Plack/Middleware/Deflater.pm
@@ -78,11 +78,6 @@ sub call {
             if ($encoding eq 'gzip' || $encoding eq 'deflate') {
                 $encoder = Plack::Middleware::Deflater::Encoder->new($encoding);
             }
-            elsif ($encoding ne 'identity') {
-                my $msg = "An acceptable encoding for the requested resource is not found.";
-                @$res = (406, [ 'Content-Type' => 'text/plain' ], [$msg]);
-                return;
-            }
 
             if ($encoder) {
                 $h->set('Content-Encoding' => $encoding);

--- a/t/no-clobber.t
+++ b/t/no-clobber.t
@@ -1,0 +1,30 @@
+use strict;
+use Test::More;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Middleware::Deflater;
+$Plack::Test::Impl = "Server";
+
+my $app = sub { [ 200, ['Content-Encoding' => 'foo'], [ 'Hello World' ] ] };
+
+test_psgi app => Plack::Middleware::Deflater->wrap($app), client => sub {
+  my $cb = shift;
+  my $req = GET "http://localhost/", 'Accept-Encoding' => 'gzip', 'Accept-Encoding' => 'foo';
+  my $res = $cb->($req);
+  is $res->content, 'Hello World';
+  is $res->header('Content-Encoding'), 'foo';
+  like $res->header('Vary'), qr/Accept-Encoding/  
+};
+
+$app = sub { [ 200, ['Content-Encoding' => 'identity'], [ 'Hello World' ] ] };
+
+test_psgi app => Plack::Middleware::Deflater->wrap($app), client => sub {
+  my $cb = shift;
+  my $req = GET "http://localhost/", 'Accept-Encoding' => 'gzip', 'Accept-Encoding' => 'foo';
+  my $res = $cb->($req);
+  is $res->decoded_content, 'Hello World';
+  is $res->header('Content-Encoding'), 'gzip';
+  like $res->header('Vary'), qr/Accept-Encoding/  
+};
+
+done_testing;


### PR DESCRIPTION
This adds a check for an existing `Content-Encoding` so that it won't be clobbered.  This allows for other middle ware, or the app itself to potentially respond to alternate content encodings.

I also took the liberty of removing a code block that appears to be unreachable.